### PR TITLE
fix local build of docs without python benchmarks

### DIFF
--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -155,8 +155,16 @@ The results are as follows.
 using BSeries, Markdown                                                   # hide
 filename = joinpath(pathof(BSeries) |> dirname |> dirname, "docs", "src", # hide
   "benchmark_python_bseries.txt")                                         # hide
-results = "```\n" * read(filename, String) * "```\n"                      # hide
-Markdown.parse(results)                                                   # hide
+try                                                                       # hide
+  results = "```\n" * read(filename, String) * "```\n"                    # hide
+  Markdown.parse(results)                                                 # hide
+catch                                                                     # hide
+  if get(ENV, "CI", nothing) != "true"                                    # hide
+    println("We are not running CI so we do not show results here.")      # hide
+  else                                                                    # hide
+    rethrow()                                                             # hide
+  end                                                                     # hide
+end                                                                       # hide
 ````
 
 
@@ -186,8 +194,16 @@ The results are as follows.
 using BSeries, Markdown                                                   # hide
 filename = joinpath(pathof(BSeries) |> dirname |> dirname, "docs", "src", # hide
   "benchmark_python_pybs.txt")                                            # hide
-results = "```\n" * read(filename, String) * "```\n"                      # hide
-Markdown.parse(results)                                                   # hide
+try                                                                       # hide
+  results = "```\n" * read(filename, String) * "```\n"                    # hide
+  Markdown.parse(results)                                                 # hide
+catch                                                                     # hide
+  if get(ENV, "CI", nothing) != "true"                                    # hide
+    println("We are not running CI so we do not show results here.")      # hide
+  else                                                                    # hide
+    rethrow()                                                             # hide
+  end                                                                     # hide
+end                                                                       # hide
 ````
 
 


### PR DESCRIPTION
Closes #65 by not printing python benchmark results when building the docs locally (not in CI). Thus, running julia in `docs`:
```julia
julia> using Pkg

julia> Pkg.activate(".")

julia> Pkg.instantiate()
...

julia> include("make.jl")
...
```

should work without requiring the text files from python benchmarks generated in https://github.com/ranocha/BSeries.jl/blob/bb7ede8ff27ce02e6c1aa1a261429e0297ffad96/.github/workflows/Documenter.yml#L54-L81

This should not affect the version of the docs build online.
