### PR TITLE
implement `order_of_accuracy`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSeries"
 uuid = "ebb8d67c-85b4-416c-b05f-5f409e808f32"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "0.1.28"
+version = "0.1.29"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/docs/src/tutorials/bseries_basics.md
+++ b/docs/src/tutorials/bseries_basics.md
@@ -82,9 +82,20 @@ latexify(coeffs4-coeffs_ex, cdot=false)
 This confirms that the method is of 4th order, since all terms involving
 smaller powers of $h$ vanish exactly.  We don't see the $h^6$ and higher
 order terms since we only generated the truncated B-series up to 5th order.
+We can also obtain the order of accuracy awithout comparing the coefficients
+to the exact solution manually:
 
-For the 2nd-order method, we get:
+```@example bseries-basics
+order_of_accuracy(coeffs4)
+```
 
+For the 2nd-order method, we get
+
+```@example bseries-basics
+order_of_accuracy(coeffs2)
+```
+
+with the following leading error terms:
 
 ```@example bseries-basics
 latexify(coeffs2-coeffs_ex, cdot=false)

--- a/docs/src/tutorials/bseries_creation.md
+++ b/docs/src/tutorials/bseries_creation.md
@@ -38,6 +38,10 @@ We can check that the classical Runge-Kutta method is indeed fourth-order accura
 series - ExactSolution(series)
 ```
 
+```@example ex:RK4
+order_of_accuracy(series)
+```
+
 
 ## B-series for additive Runge-Kutta methods
 
@@ -73,6 +77,10 @@ the exact solution.
 
 ```@example ex:SV
 series - ExactSolution(series)
+```
+
+```@example ex:SV
+order_of_accuracy(series)
 ```
 
 
@@ -136,6 +144,10 @@ the B-series of the exact solution, truncated at the same order.
 series - ExactSolution(series)
 ```
 
+```@example ex:AVF
+order_of_accuracy(series)
+```
+
 ### References
 
 - Robert I. McLachlan, G. Reinout W. Quispel, and Nicolas Robidoux.
@@ -182,7 +194,7 @@ series_a = bseries(rk_a, 6)
 Note that this method is fourth-order accurate:
 
 ```@example ex:compose
-series_a - ExactSolution(series_a)
+order_of_accuracy(series_a)
 ```
 
 Next, we set up the starting procedure (method "b" in Butcher's paper):
@@ -196,6 +208,10 @@ A = [0 0 0 0 0;
 b = [19 // 144, 0, 25 // 48, 2 // 9, 1 // 8]
 rk_b = RungeKuttaMethod(A, b)
 series_b = bseries(rk_b, 6)
+```
+
+```@example ex:compose
+order_of_accuracy(series_b)
 ```
 
 Note that this method is only third-order accurate - as is the finishing
@@ -212,6 +228,10 @@ rk_c = RungeKuttaMethod(A, b)
 series_c = bseries(rk_c, 6)
 ```
 
+```@example ex:compose
+order_of_accuracy(series_c)
+```
+
 Finally, we can compose the three methods to obtain
 
 ```@example ex:compose
@@ -220,6 +240,10 @@ series = compose(series_b, series_a, series_c, normalize_stepsize = true)
 
 Note that this composition has to be read from left to right. Finally, we check
 that the resulting `series` is indeed fifth-order accurate:
+
+```@example ex:compose
+order_of_accuracy(series)
+```
 
 ```@example ex:compose
 series - ExactSolution(series)

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -274,7 +274,6 @@ for op in (:+, :-)
         V = promote_type(valtype(series1), valtype(series2))
         series_result = TruncatedBSeries{T, V}()
         for (key, val1, val2) in zip(series_keys, values(series1), values(series2))
-            @info "op" key val1 val2
             series_result[key] = ($op)(val1, val2)
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,7 +154,7 @@ using Aqua: Aqua
             rk = RungeKuttaMethod(A, b)
             series = bseries(rk, 5)
             @test @inferred(order_of_accuracy(series)) == 4
-            @test @inferred(order_of_accuracy(series; atol=10*eps())) == 4
+            @test @inferred(order_of_accuracy(series; atol = 10 * eps())) == 4
 
             series = bseries(rk, 3)
             @test @inferred(order_of_accuracy(series)) == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1172,6 +1172,7 @@ using Aqua: Aqua
             series_integrator = @inferred bseries(ark, 1)
             series_exact = @inferred ExactSolution(series_integrator)
             @test mapreduce(==, &, values(series_integrator), values(series_exact))
+            @test @inferred(order_of_accuracy(series_integrator)) == 1
 
             # not second-order accurate
             series_integrator = @inferred bseries(ark, 2)
@@ -1234,6 +1235,7 @@ using Aqua: Aqua
             series_integrator = @inferred bseries(ark, 2)
             series_exact = @inferred ExactSolution(series_integrator)
             @test mapreduce(==, &, values(series_integrator), values(series_exact))
+            @test @inferred(order_of_accuracy(series_integrator)) == 2
 
             # not third-order accurate
             series_integrator = @inferred bseries(ark, 3)
@@ -1342,6 +1344,7 @@ using Aqua: Aqua
             series_integrator = @inferred bseries(ark, 3)
             series_exact = @inferred ExactSolution(series_integrator)
             @test mapreduce(==, &, values(series_integrator), values(series_exact))
+            @test @inferred(order_of_accuracy(series_integrator)) == 3
 
             # not fourth-order accurate
             series_integrator = @inferred bseries(ark, 4)


### PR DESCRIPTION
I added a function `order_of_accuracy` as convenience function to obtain the order of accuracy of a B-series (used as numerical integrator).