### PR TITLE
rendered LaTeX output in introduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ docs/build
 docs/src/contributing.md
 docs/src/license.md
 docs/src/benchmark_python_*.txt
+docs/dev/*.pdf
+docs/dev/*.png
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSeries"
 uuid = "ebb8d67c-85b4-416c-b05f-5f409e808f32"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "0.1.36"
+version = "0.1.37"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/docs/dev/bseries_creation_eq1.tex
+++ b/docs/dev/bseries_creation_eq1.tex
@@ -1,0 +1,56 @@
+\documentclass[
+  preview,
+  border={0pt 1pt 0pt 1pt}, % left bottom right top
+]{standalone}
+
+% Butcher trees, cf. https://tex.stackexchange.com/questions/283343/butcher-trees-in-tikz
+\usepackage{forest}
+\forestset{
+  */.style={
+    delay+={append={[]},}
+  },
+  rooted tree/.style={
+    for tree={
+      grow'=90,
+      parent anchor=center,
+      child anchor=center,
+      s sep=2.5pt,
+      if level=0{
+        baseline
+      }{},
+      delay={
+        if content={*}{
+          content=,
+          append={[]}
+        }{}
+      }
+    },
+    before typesetting nodes={
+      for tree={
+        circle,
+        fill,
+        minimum width=3pt,
+        inner sep=0pt,
+        child anchor=center,
+      },
+    },
+    before computing xy={
+      for tree={
+        l=5pt,
+      }
+    }
+  }
+}
+\DeclareDocumentCommand\rootedtree{o}{\Forest{rooted tree [#1]}}
+
+\usepackage{amssymb}
+
+\begin{document}
+
+\(\displaystyle
+F_{f}\mathopen{}\left( \varnothing \right)\mathclose{} + h F_{f}\mathopen{}\left( \rootedtree[] \right)\mathclose{} + \frac{h^{2}}{2} F_{f}\mathopen{}\left( \rootedtree[[]] \right)\mathclose{} + \frac{h^{3}}{8 \alpha} F_{f}\mathopen{}\left( \rootedtree[[][]] \right)\mathclose{}
+\)
+
+\end{document}
+
+% pdftoppm -png -rx 300 -ry 300 -f 1 -l 1 bseries_creation_eq1.pdf bseries_creation_eq1

--- a/docs/dev/bseries_creation_eq2.tex
+++ b/docs/dev/bseries_creation_eq2.tex
@@ -1,0 +1,56 @@
+\documentclass[
+  preview,
+  border={0pt 1pt 0pt 1pt}, % left bottom right top
+]{standalone}
+
+% Butcher trees, cf. https://tex.stackexchange.com/questions/283343/butcher-trees-in-tikz
+\usepackage{forest}
+\forestset{
+  */.style={
+    delay+={append={[]},}
+  },
+  rooted tree/.style={
+    for tree={
+      grow'=90,
+      parent anchor=center,
+      child anchor=center,
+      s sep=2.5pt,
+      if level=0{
+        baseline
+      }{},
+      delay={
+        if content={*}{
+          content=,
+          append={[]}
+        }{}
+      }
+    },
+    before typesetting nodes={
+      for tree={
+        circle,
+        fill,
+        minimum width=3pt,
+        inner sep=0pt,
+        child anchor=center,
+      },
+    },
+    before computing xy={
+      for tree={
+        l=5pt,
+      }
+    }
+  }
+}
+\DeclareDocumentCommand\rootedtree{o}{\Forest{rooted tree [#1]}}
+
+\usepackage{amssymb}
+
+\begin{document}
+
+\(\displaystyle
+F_{f}\mathopen{}\left( \varnothing \right)\mathclose{} + h F_{f}\mathopen{}\left( \rootedtree[] \right)\mathclose{} + \frac{1}{2} h^{2} F_{f}\mathopen{}\left( \rootedtree[[]] \right)\mathclose{} + \frac{1}{6} h^{3} F_{f}\mathopen{}\left( \rootedtree[[[]]] \right)\mathclose{} + \frac{1}{6} h^{3} F_{f}\mathopen{}\left( \rootedtree[[][]] \right)\mathclose{} + \frac{1}{24} h^{4} F_{f}\mathopen{}\left( \rootedtree[[[[]]]] \right)\mathclose{} + \frac{1}{24} h^{4} F_{f}\mathopen{}\left( \rootedtree[[[][]]] \right)\mathclose{} + \frac{1}{8} h^{4} F_{f}\mathopen{}\left( \rootedtree[[[]][]] \right)\mathclose{} + \frac{1}{24} h^{4} F_{f}\mathopen{}\left( \rootedtree[[][][]] \right)\mathclose{} + \frac{1}{96} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[][]]]] \right)\mathclose{} + \frac{1}{48} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[]][]]] \right)\mathclose{} + \frac{1}{24} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[]]][]] \right)\mathclose{} + \frac{1}{144} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[][][]]] \right)\mathclose{} + \frac{1}{32} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[][]][]] \right)\mathclose{} + \frac{1}{32} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[]][[]]] \right)\mathclose{} + \frac{5}{96} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[]][][]] \right)\mathclose{} + \frac{5}{576} h^{5} F_{f}\mathopen{}\left( \rootedtree[[][][][]] \right)\mathclose{}
+\)
+
+\end{document}
+
+% pdftoppm -png -rx 300 -ry 300 -f 1 -l 1 bseries_creation_eq2.pdf bseries_creation_eq2

--- a/docs/dev/bseries_creation_eq3.tex
+++ b/docs/dev/bseries_creation_eq3.tex
@@ -1,0 +1,56 @@
+\documentclass[
+  preview,
+  border={0pt 1pt 0pt 1pt}, % left bottom right top
+]{standalone}
+
+% Butcher trees, cf. https://tex.stackexchange.com/questions/283343/butcher-trees-in-tikz
+\usepackage{forest}
+\forestset{
+  */.style={
+    delay+={append={[]},}
+  },
+  rooted tree/.style={
+    for tree={
+      grow'=90,
+      parent anchor=center,
+      child anchor=center,
+      s sep=2.5pt,
+      if level=0{
+        baseline
+      }{},
+      delay={
+        if content={*}{
+          content=,
+          append={[]}
+        }{}
+      }
+    },
+    before typesetting nodes={
+      for tree={
+        circle,
+        fill,
+        minimum width=3pt,
+        inner sep=0pt,
+        child anchor=center,
+      },
+    },
+    before computing xy={
+      for tree={
+        l=5pt,
+      }
+    }
+  }
+}
+\DeclareDocumentCommand\rootedtree{o}{\Forest{rooted tree [#1]}}
+
+\usepackage{amssymb}
+
+\begin{document}
+
+\(\displaystyle
+F_{f}\mathopen{}\left( \varnothing \right)\mathclose{} + h F_{f}\mathopen{}\left( \rootedtree[] \right)\mathclose{} + \frac{1}{2} h^{2} F_{f}\mathopen{}\left( \rootedtree[[]] \right)\mathclose{} + \frac{1}{6} h^{3} F_{f}\mathopen{}\left( \rootedtree[[[]]] \right)\mathclose{} + \frac{1}{6} h^{3} F_{f}\mathopen{}\left( \rootedtree[[][]] \right)\mathclose{} + \frac{1}{24} h^{4} F_{f}\mathopen{}\left( \rootedtree[[[[]]]] \right)\mathclose{} + \frac{1}{24} h^{4} F_{f}\mathopen{}\left( \rootedtree[[[][]]] \right)\mathclose{} + \frac{1}{8} h^{4} F_{f}\mathopen{}\left( \rootedtree[[[]][]] \right)\mathclose{} + \frac{1}{24} h^{4} F_{f}\mathopen{}\left( \rootedtree[[][][]] \right)\mathclose{} + \frac{1}{120} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[[]]]]] \right)\mathclose{} + \frac{1}{120} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[][]]]] \right)\mathclose{} + \frac{1}{40} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[]][]]] \right)\mathclose{} + \frac{1}{30} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[]]][]] \right)\mathclose{} + \frac{1}{120} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[][][]]] \right)\mathclose{} + \frac{1}{30} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[][]][]] \right)\mathclose{} + \frac{1}{40} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[]][[]]] \right)\mathclose{} + \frac{1}{20} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[]][][]] \right)\mathclose{} + \frac{1}{120} h^{5} F_{f}\mathopen{}\left( \rootedtree[[][][][]] \right)\mathclose{}
+\)
+
+\end{document}
+
+% pdftoppm -png -rx 300 -ry 300 -f 1 -l 1 bseries_creation_eq3.pdf bseries_creation_eq3

--- a/docs/dev/bseries_creation_eq4.tex
+++ b/docs/dev/bseries_creation_eq4.tex
@@ -1,0 +1,56 @@
+\documentclass[
+  preview,
+  border={0pt 1pt 0pt 1pt}, % left bottom right top
+]{standalone}
+
+% Butcher trees, cf. https://tex.stackexchange.com/questions/283343/butcher-trees-in-tikz
+\usepackage{forest}
+\forestset{
+  */.style={
+    delay+={append={[]},}
+  },
+  rooted tree/.style={
+    for tree={
+      grow'=90,
+      parent anchor=center,
+      child anchor=center,
+      s sep=2.5pt,
+      if level=0{
+        baseline
+      }{},
+      delay={
+        if content={*}{
+          content=,
+          append={[]}
+        }{}
+      }
+    },
+    before typesetting nodes={
+      for tree={
+        circle,
+        fill,
+        minimum width=3pt,
+        inner sep=0pt,
+        child anchor=center,
+      },
+    },
+    before computing xy={
+      for tree={
+        l=5pt,
+      }
+    }
+  }
+}
+\DeclareDocumentCommand\rootedtree{o}{\Forest{rooted tree [#1]}}
+
+\usepackage{amssymb}
+
+\begin{document}
+
+\(\displaystyle
+\frac{-1}{120} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[[]]]]] \right)\mathclose{} + \frac{1}{480} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[][]]]] \right)\mathclose{} + \frac{-1}{240} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[]][]]] \right)\mathclose{} + \frac{1}{120} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[[]]][]] \right)\mathclose{} + \frac{-1}{720} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[][][]]] \right)\mathclose{} + \frac{-1}{480} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[][]][]] \right)\mathclose{} + \frac{1}{160} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[]][[]]] \right)\mathclose{} + \frac{1}{480} h^{5} F_{f}\mathopen{}\left( \rootedtree[[[]][][]] \right)\mathclose{} + \frac{1}{2880} h^{5} F_{f}\mathopen{}\left( \rootedtree[[][][][]] \right)\mathclose{}
+\)
+
+\end{document}
+
+% pdftoppm -png -rx 300 -ry 300 -f 1 -l 1 bseries_creation_eq4.pdf bseries_creation_eq4

--- a/docs/dev/bseries_creation_eq5.tex
+++ b/docs/dev/bseries_creation_eq5.tex
@@ -1,0 +1,56 @@
+\documentclass[
+  preview,
+  border={0pt 1pt 0pt 1pt}, % left bottom right top
+]{standalone}
+
+% Butcher trees, cf. https://tex.stackexchange.com/questions/283343/butcher-trees-in-tikz
+\usepackage{forest}
+\forestset{
+  */.style={
+    delay+={append={[]},}
+  },
+  rooted tree/.style={
+    for tree={
+      grow'=90,
+      parent anchor=center,
+      child anchor=center,
+      s sep=2.5pt,
+      if level=0{
+        baseline
+      }{},
+      delay={
+        if content={*}{
+          content=,
+          append={[]}
+        }{}
+      }
+    },
+    before typesetting nodes={
+      for tree={
+        circle,
+        fill,
+        minimum width=3pt,
+        inner sep=0pt,
+        child anchor=center,
+      },
+    },
+    before computing xy={
+      for tree={
+        l=5pt,
+      }
+    }
+  }
+}
+\DeclareDocumentCommand\rootedtree{o}{\Forest{rooted tree [#1]}}
+
+\usepackage{amssymb}
+
+\begin{document}
+
+\(\displaystyle
+\frac{ - h^{3}}{6} F_{f}\mathopen{}\left( \rootedtree[[[]]] \right)\mathclose{} + h^{3} \left( \frac{-1}{6} + \frac{1}{8 \alpha} \right) F_{f}\mathopen{}\left( \rootedtree[[][]] \right)\mathclose{}
+\)
+
+\end{document}
+
+% pdftoppm -png -rx 300 -ry 300 -f 1 -l 1 bseries_creation_eq5.pdf bseries_creation_eq5

--- a/docs/src/tutorials/bseries_basics.md
+++ b/docs/src/tutorials/bseries_basics.md
@@ -31,13 +31,7 @@ Butcher's book. The rooted trees written in this way can be rendered in LaTeX
 using the package [`forest`](https://ctan.org/pkg/forest); unfortunately,
 there is no easy way to render them in the browser. Nevertheless, you can render
 them using LaTeX with an appropriate preamble, see the docstring of
-`RootedTrees.latexify`.
-
-````@example bseries-basics
-@doc RootedTrees.latexify
-````
-
-The rendered output looks like this:
+`RootedTrees.latexify`. The rendered output looks like this:
 
 ![bseries_creation_eq1-1](https://user-images.githubusercontent.com/12693098/193994163-e53d24a8-f74e-4f95-b07d-225ebde83f70.png)
 

--- a/docs/src/tutorials/bseries_basics.md
+++ b/docs/src/tutorials/bseries_basics.md
@@ -26,16 +26,28 @@ coeffs2 = bseries(A, b, c, 3)
 latexify(coeffs2, cdot=false)
 ```
 
+The rooted trees are printed as nested lists, essentially in the form used in
+Butcher's book. The rooted trees written in this way can be rendered in LaTeX
+using the package [`forest`](https://ctan.org/pkg/forest); unfortunately,
+there is no easy way to render them in the browser. Nevertheless, you can render
+them using LaTeX with an appropriate preamble, see the docstring of
+`RootedTrees.latexify`.
+
+```@example bseries-basics
+@doc RootedTrees.latexify
+```
+
+The rendered output looks like this:
+
+![bseries_creation_eq1-1](https://user-images.githubusercontent.com/12693098/193994163-e53d24a8-f74e-4f95-b07d-225ebde83f70.png)
+
 We have generated the B-series up to terms of order $h^3$.  The terms $F_f()$
 represent elementary differentials, which are products of derivatives of the
 ODE right-hand side.  Since we haven't specified an ODE, these are indicated
-simply by the associated rooted tree.  The rooted trees are printed as nested
-lists, essentially in the form used in Butcher's book.  The rooted trees written
-in this way can be rendered in LaTeX using the package [`forest`](https://ctan.org/pkg/forest); unfortunately,
-there is no easy way to render them in the browser.
+simply by the associated rooted tree.
+
 
 Here is a B-series for the classical 4th-order method, expanded up to 5th-order terms:
-
 
 ```@example bseries-basics
 A = [0 0 0 0; 1//2 0 0 0; 0 1//2 0 0; 0 0 1 0];
@@ -45,6 +57,8 @@ c = [0, 1//2, 1//2, 1];
 coeffs4 = bseries(A, b, c, 5)
 latexify(coeffs4, cdot=false)
 ```
+
+![bseries_creation_eq2-1](https://user-images.githubusercontent.com/12693098/193994166-a9178001-702d-4f9b-a3f6-6a89251ddb7f.png)
 
 We can also print out the B-series coefficients this way:
 
@@ -59,12 +73,15 @@ The corresponding coefficients are on the right.
 You can use the function `RootedTrees.set_printing_style` to change the
 printing style globally. For example, you can use the notation of Butcher
 as follows.
+
 ```@example bseries-basics
 RootedTrees.set_printing_style("butcher")
 coeffs4
 ```
+
 To use the level sequence representation, you need to change the printing style
 again.
+
 ```@example bseries-basics
 RootedTrees.set_printing_style("sequence")
 coeffs4
@@ -85,13 +102,15 @@ coeffs_ex = ExactSolution(coeffs4)
 latexify(coeffs_ex, cdot=false)
 ```
 
-We can find the local error by subtracting the exact solution B-series from the RK method B-series:
+![bseries_creation_eq3-1](https://user-images.githubusercontent.com/12693098/193994175-22356d01-edb9-44b6-afd3-4354a3daffc6.png)
 
+We can find the local error by subtracting the exact solution B-series from the RK method B-series:
 
 ```@example bseries-basics
 latexify(coeffs4-coeffs_ex, cdot=false)
 ```
 
+![bseries_creation_eq4-1](https://user-images.githubusercontent.com/12693098/193994179-7ffcced2-6760-46fc-829a-d6c5814d543f.png)
 
 This confirms that the method is of 4th order, since all terms involving
 smaller powers of $h$ vanish exactly.  We don't see the $h^6$ and higher
@@ -114,6 +133,8 @@ with the following leading error terms:
 ```@example bseries-basics
 latexify(coeffs2-coeffs_ex, cdot=false)
 ```
+
+![bseries_creation_eq5-1](https://user-images.githubusercontent.com/12693098/193994181-108aa3a7-e2fb-4247-a770-9647ebe861c8.png)
 
 This confirms again the accuracy of the method, and shows us that we
 can eliminate one of the leading error terms completely if we take

--- a/docs/src/tutorials/bseries_basics.md
+++ b/docs/src/tutorials/bseries_basics.md
@@ -33,9 +33,9 @@ there is no easy way to render them in the browser. Nevertheless, you can render
 them using LaTeX with an appropriate preamble, see the docstring of
 `RootedTrees.latexify`.
 
-```@example bseries-basics
+````@example bseries-basics
 @doc RootedTrees.latexify
-```
+````
 
 The rendered output looks like this:
 

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1,5 +1,5 @@
 module BSeries
- 
+
 @doc read(joinpath(dirname(@__DIR__), "README.md"), String) BSeries
 
 import Base: +, -, *, /, \

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1,5 +1,5 @@
 module BSeries
-
+ 
 @doc read(joinpath(dirname(@__DIR__), "README.md"), String) BSeries
 
 import Base: +, -, *, /, \


### PR DESCRIPTION
Closes #83

This is a quick and dirty way to render the LaTeX output in the introduction - I rendered it locally based on the added tex files in this PR and just include the resulting images in the docs. We need to take care when updating the examples, though.