### PR TITLE
limit Python to v3.9

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
       - name: Run Python benchmarks
         run: |
           # Install pybs and run benchmark


### PR DESCRIPTION
It looks like Python3 made a breaking change when going from 3.9 to 3.10, see https://bobbyhadz.com/blog/python-importerror-cannot-import-name-hashable-from-collections
This caused our CI failure in https://github.com/ranocha/BSeries.jl/pull/85.

Here, I just set Python to the old version 3.9 since [pybs](https://github.com/henriksu/pybs) is not likely to be updated.

@ketch Do you have another suggestion? 