### PR TITLE
provide convenience function for the AVF method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSeries"
 uuid = "ebb8d67c-85b4-416c-b05f-5f409e808f32"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "0.1.49"
+version = "0.1.50"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSeries"
 uuid = "ebb8d67c-85b4-416c-b05f-5f409e808f32"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "0.1.50"
+version = "0.1.51"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -31,7 +31,7 @@ export modified_equation, modifying_integrator
 
 export elementary_differentials
 
-export average_vector_field_method
+export AverageVectorFieldMethod
 
 export MultirateInfinitesimalSplitMethod
 
@@ -470,25 +470,17 @@ end
 # should create a lazy version, optionally a memoized one
 
 """
-    average_vector_field_method([T=Rational{Int},] order)
+    AverageVectorFieldMethod([T=Rational{Int}])
 
-Construct the B-series of the average vector field (AVF) method up to the given
-`order`, using coefficients of type `T`.
-
-See also [`bseries`](@ref).
-
-!!! note "Normalization by elementary differentials"
-    The coefficients of the B-series returned by this method need to be
-    multiplied by a power of the time step divided by the `symmetry` of the
-    rooted tree and multiplied by the corresponding elementary differential
-    of the input vector field ``f``.
-    See also [`evaluate`](@ref).
+Construct a representation of the average vector field (AVF) method using
+coefficients of type `T`. You can pass it as argument to [`bseries`](@ref)
+to construct the corresponding B-series.
 
 # Examples
 
 We can generate this as follows.
 ```jldoctest
-julia> series = average_vector_field_method(3)
+julia> series = bseries(AverageVectorFieldMethod(), 3)
 TruncatedBSeries{RootedTree{Int64, Vector{Int64}}, Rational{Int64}} with 5 entries:
   RootedTree{Int64}: Int64[]   => 1//1
   RootedTree{Int64}: [1]       => 1//1
@@ -508,11 +500,25 @@ The B-series of the average vector field (AVF) method is given by
   ESAIM: Mathematical Modelling and Numerical Analysis 43, no. 4 (2009): 645-649.
   [DOI: 10.1051/m2an/2009020](https://doi.org/10.1051/m2an/2009020)
 """
-function average_vector_field_method(order)
-    average_vector_field_method(Rational{Int}, order)
-end
+struct AverageVectorFieldMethod{T} end
 
-function average_vector_field_method(::Type{T}, o) where {T}
+AverageVectorFieldMethod() = AverageVectorFieldMethod(Rational{Int})
+AverageVectorFieldMethod(::Type{T}) where {T} = AverageVectorFieldMethod{T}()
+
+"""
+    bseries(avf::AverageVectorFieldMethod, order)
+
+Compute the B-series of the [`AverageVectorFieldMethod`](@ref) up to a
+prescribed integer `order`.
+
+!!! note "Normalization by elementary differentials"
+    The coefficients of the B-series returned by `bseries` need to be
+    multiplied by a power of the time step divided by the `symmetry` of the
+    rooted tree and multiplied by the corresponding elementary differential
+    of the input vector field ``f``.
+    See also [`evaluate`](@ref).
+"""
+function bseries(::AverageVectorFieldMethod{T}, o) where {T}
     bseries(o) do t, series
         if order(t) in (0, 1)
             return one(T)

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -31,6 +31,8 @@ export modified_equation, modifying_integrator
 
 export elementary_differentials
 
+export average_vector_field_method
+
 export MultirateInfinitesimalSplitMethod
 
 export renormalize!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,6 +216,12 @@ using Aqua: Aqua
         end
     end
 
+    @testset "average Vector field (AVF) method" begin
+        series = @inferred(average_vector_field_method(6))
+        @test @inferred(order_of_accuracy(series)) == 2
+        @test is_energy_preserving(series)
+    end
+
     @testset "substitute" begin
         Symbolics.@variables a1 a2 a31 a32
         a = OrderedDict{RootedTrees.RootedTree{Int, Vector{Int}}, Symbolics.Num}(rootedtree(Int[]) => 1,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,9 +217,17 @@ using Aqua: Aqua
     end
 
     @testset "average Vector field (AVF) method" begin
-        series = @inferred(average_vector_field_method(6))
-        @test @inferred(order_of_accuracy(series)) == 2
-        @test is_energy_preserving(series)
+        @testset "Rational coefficients" begin
+            series = @inferred(bseries(AverageVectorFieldMethod(), 6))
+            @test @inferred(order_of_accuracy(series)) == 2
+            @test is_energy_preserving(series)
+        end
+
+        @testset "Floating point coefficients" begin
+            series = @inferred(bseries(AverageVectorFieldMethod(Float64), 6))
+            @test @inferred(order_of_accuracy(series)) == 2
+            @test is_energy_preserving(series)
+        end
     end
 
     @testset "substitute" begin


### PR DESCRIPTION
I think it would be nice to have a convenience function returning the B-series of the AVF method. However, I'm not sure about the best interface. We could have

1. `bseries(AverageVectorFieldMethod(), up_to_order)`
2. `average_vector_field_method(up_to_order)`

with options to allow different types of the coefficients, e.g.,

1. `bseries(AverageVectorFieldMethod(Float64), up_to_order)`
2. `average_vector_field_method(Float64, up_to_order)`

Option 1 would be more close to most methods of `bseries` we have so far - but the return value of `AverageVectorFieldMethod()` would have no further use (at the moment). Option 2 is more close to something like `zeros`.

What would you prefer, @ketch?