### PR TITLE
Improve performance of `is_energy_preserving` via sparse matrices

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -36,6 +36,6 @@ jobs:
               exit(0)
           else
               @error "Some files have not been formatted !!!"
-              write(stdout, out)
+              println(out)
               exit(1)
           end'

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -32,10 +32,10 @@ jobs:
         run: |
           julia -e '
           out = Cmd(`git diff --name-only`) |> read |> String
+          out_verbose = Cmd(`git diff`) |> read |> String
           if out == ""
               exit(0)
           else
-              @error "Some files have not been formatted !!!"
-              println(out)
+              @error "Some files have not been formatted !!!" out out_verbose
               exit(1)
           end'

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 RootedTrees = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSeries"
 uuid = "ebb8d67c-85b4-416c-b05f-5f409e808f32"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "0.1.52"
+version = "0.1.53"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1686,7 +1686,7 @@ end
 # condition.
 function _is_energy_preserving(trees, coefficients)
     # TODO: `Float32` would also be nice to have. However, the default tolerance
-    #       of the rank computation is based on `Flaot64`. Thus, it will usually
+    #       of the rank computation is based on `Float64`. Thus, it will usually
     #       not work with coefficients given only in 32 bit precision.
     if eltype(coefficients) <: Union{Float64, Rational{Int8}, Rational{Int16},
         Rational{Int32}, Rational{Int64}, Rational{Int128}}

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1685,7 +1685,10 @@ end
 # Checks whether `trees` and `ocefficients` satisfify the energy_preserving
 # condition.
 function _is_energy_preserving(trees, coefficients)
-    if eltype(coefficients) <: Union{Float32, Float64, Rational{Int8}, Rational{Int16},
+    # TODO: `Float32` would also be nice to have. However, the default tolerance
+    #       of the rank computation is based on `Flaot64`. Thus, it will usually
+    #       not work with coefficients given only in 32 bit precision.
+    if eltype(coefficients) <: Union{Float64, Rational{Int8}, Rational{Int16},
         Rational{Int32}, Rational{Int64}, Rational{Int128}}
         # These types support efficient computations in sparse matrices
         _is_energy_preserving_sparse(trees, coefficients)

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1688,8 +1688,12 @@ function _is_energy_preserving(trees, coefficients)
     # TODO: `Float32` would also be nice to have. However, the default tolerance
     #       of the rank computation is based on `Float64`. Thus, it will usually
     #       not work with coefficients given only in 32 bit precision.
-    if eltype(coefficients) <: Union{Float64, Rational{Int8}, Rational{Int16},
-             Rational{Int32}, Rational{Int64}, Rational{Int128}}
+    # For very few coefficients, dense operations are more efficient than
+    # sparse operations.
+    if (length(coefficients) > 20 &&
+        eltype(coefficients) <: Union{Float64,
+              Rational{Int8}, Rational{Int16}, Rational{Int32}, Rational{Int64},
+              Rational{Int128}})
         # These types support efficient computations in sparse matrices
         _is_energy_preserving_sparse(trees, coefficients)
     else

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1686,7 +1686,8 @@ end
 # condition.
 function _is_energy_preserving(trees, coefficients)
     if eltype(coefficients) <: Union{Float32, Float64, Rational{Int8}, Rational{Int16},
-                                     Rational{Int32}, Rational{Int64}, Rational{Int128}}
+        Rational{Int32}, Rational{Int64}, Rational{Int128}}
+        # These types support efficient computations in sparse matrices
         _is_energy_preserving_sparse(trees, coefficients)
     else
         _is_energy_preserving_dense(trees, coefficients)

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -1689,7 +1689,7 @@ function _is_energy_preserving(trees, coefficients)
     #       of the rank computation is based on `Float64`. Thus, it will usually
     #       not work with coefficients given only in 32 bit precision.
     if eltype(coefficients) <: Union{Float64, Rational{Int8}, Rational{Int16},
-        Rational{Int32}, Rational{Int64}, Rational{Int128}}
+             Rational{Int32}, Rational{Int64}, Rational{Int128}}
         # These types support efficient computations in sparse matrices
         _is_energy_preserving_sparse(trees, coefficients)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1976,22 +1976,16 @@ using Aqua: Aqua
         end
 
         @testset "Floating point coefficients" begin
-            # AVF method again
-            series = bseries(7) do t, series
-                if order(t) in (0, 1)
-                    return 1.0
-                else
-                    v = 1.0
-                    n = 0
-                    for subtree in SubtreeIterator(t)
-                        v *= series[subtree]
-                        n += 1
-                    end
-                    return v / (n + 1)
-                end
-            end
+            # AVF method again with various types of coefficients
+            series = bseries(AverageVectorFieldMethod(Float32), 7)
+            @test is_energy_preserving(series)
+
+            series = bseries(AverageVectorFieldMethod(Float64), 7)
+            @test is_energy_preserving(series)
+
+            series = bseries(AverageVectorFieldMethod(BigFloat), 7)
             # TODO: This test is currently broken and throws an error
-            @test_skip is_energy_preserving(series)
+            @test_broken is_energy_preserving(series)
         end
 
         @testset "Symbolic coefficients" begin


### PR DESCRIPTION
This tackles the biggest chunk of #130. 

Current `main`:
```julia
julia> using BSeries

julia> begin # second run after compilation

       # rational coefficients
       series = bseries(AverageVectorFieldMethod(), 10)
       @time is_energy_preserving(series)

       # floating point coefficients
       series = bseries(AverageVectorFieldMethod(Float64), 10)
       @time is_energy_preserving(series)

       end
  0.664049 seconds (119.29 k allocations: 88.295 MiB, 0.62% gc time)
  0.560968 seconds (118.06 k allocations: 80.759 MiB, 0.35% gc time)
true
```

This PR:
```julia
julia> using BSeries

julia> begin # second run after compilation

       # rational coefficients
       series = bseries(AverageVectorFieldMethod(), 10)
       @time is_energy_preserving(series)

       # floating point coefficients
       series = bseries(AverageVectorFieldMethod(Float64), 10)
       @time is_energy_preserving(series)

       end
  0.397417 seconds (111.10 k allocations: 13.948 MiB)
  0.327424 seconds (109.87 k allocations: 14.197 MiB)
true
```

With this PR, `modified_equation` takes 93% of the total runtime of `is_energy_preserving(series)` for `series = bseries(AverageVectorFieldMethod(Float64), 10)`.