### PR TITLE
first version of continuous stage Runge-Kutta methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSeries"
 uuid = "ebb8d67c-85b4-416c-b05f-5f409e808f32"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "0.1.55"
+version = "0.1.56"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -414,8 +414,18 @@ function bseries(f::Function, order, iterator_type = RootedTreeIterator)
     t = first(iterator_type(0))
     v = f(t, nothing)
 
+    V_tmp = typeof(v)
+    if V_tmp <: Integer
+        # If people use integer coefficients, they will likely want to have results
+        # as exact as possible. However, general terms are not integers. Thus, we
+        # use rationals instead.
+        V = Rational{V_tmp}
+    else
+        V = V_tmp
+    end
+
     # Setup the series
-    series = TruncatedBSeries{typeof(t), typeof(v)}()
+    series = TruncatedBSeries{typeof(t), V}()
     series[copy(t)] = v
 
     for o in 1:order
@@ -782,8 +792,16 @@ end
 # Equation (2.6) of Miyatake & Butcher (2016)
 function _matrix_a(csrk::ContinuousStageRungeKuttaMethod)
     M = csrk.matrix
-    T = eltype(M)
     s = size(M, 1)
+    T_tmp = eltype(M)
+    if T_tmp <: Integer
+        # If people use integer coefficients, they will likely want to have results
+        # as exact as possible. However, general terms are not integers. Thus, we
+        # use rationals instead.
+        T = Rational{T_tmp}
+    else
+        T = T_tmp
+    end
 
     τ = Vector{Polynomial{T, :τ}}(undef, s)
     for i in 1:s

--- a/src/BSeries.jl
+++ b/src/BSeries.jl
@@ -798,7 +798,6 @@ function _matrix_a(csrk::ContinuousStageRungeKuttaMethod)
     return A_τζ
 end
 
-
 # TODO: Documentation (tutorial), Base.show, etc.
 """
     MultirateInfinitesimalSplitMethod(A, D, G, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1554,7 +1554,7 @@ using Aqua: Aqua
 
     @testset "Continuous stage Runge-Kutta methods interface" begin
         @testset "Average vector field method" begin
-            M = fill(1//1, 1, 1)
+            M = fill(1 // 1, 1, 1)
             csrk = @inferred ContinuousStageRungeKuttaMethod(M)
 
             # TODO: This is no type stable at the moment
@@ -1571,7 +1571,7 @@ using Aqua: Aqua
             #   SIAM Journal on Numerical Analysis 54, no. 3 (2016):
             #   [DOI: 10.1137/15M1020861](https://doi.org/10.1137/15M1020861)
             M = [-6//5 72//5 -36//1 24//1
-                 72//5  -144//5 -48//1 72//1
+                 72//5 -144//5 -48//1 72//1
                  -36//1 -48//1 720//1 -720//1
                  24//1 72//1 -720//1 720//1]
             csrk = @inferred ContinuousStageRungeKuttaMethod(M)
@@ -1599,8 +1599,8 @@ using Aqua: Aqua
             # Examples in Section 5.3.1
             α = SymEngine.symbols("α")
             α1 = 1 / (36 * α - 7)
-            M = [α1+4 -6*α1-6 6*α1
-                 -6*α1-6 36*α1+12 -36*α1
+            M = [α1+4 -6 * α1-6 6*α1
+                 -6 * α1-6 36 * α1+12 -36*α1
                  6*α1 -36*α1 36*α1]
             csrk = @inferred ContinuousStageRungeKuttaMethod(M)
 
@@ -1627,8 +1627,8 @@ using Aqua: Aqua
             # Examples in Section 5.3.1
             α = SymPy.symbols("α", real = true)
             α1 = 1 / (36 * α - 7)
-            M = [α1+4 -6*α1-6 6*α1
-                 -6*α1-6 36*α1+12 -36*α1
+            M = [α1+4 -6 * α1-6 6*α1
+                 -6 * α1-6 36 * α1+12 -36*α1
                  6*α1 -36*α1 36*α1]
             csrk = @inferred ContinuousStageRungeKuttaMethod(M)
 
@@ -1646,8 +1646,8 @@ using Aqua: Aqua
             # Examples in Section 5.3.1
             Symbolics.@variables α
             α1 = 1 / (36 * α - 7)
-            M = [α1+4 -6*α1-6 6*α1
-                 -6*α1-6 36*α1+12 -36*α1
+            M = [α1+4 -6 * α1-6 6*α1
+                 -6 * α1-6 36 * α1+12 -36*α1
                  6*α1 -36*α1 36*α1]
             csrk = @inferred ContinuousStageRungeKuttaMethod(M)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1564,6 +1564,17 @@ using Aqua: Aqua
             @test all(iszero, values(series - series_avf))
         end
 
+        @testset "Average vector field method with integer coefficient" begin
+            M = fill(1, 1, 1)
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 8)
+            series = bseries(csrk, 8)
+            series_avf = @inferred bseries(AverageVectorFieldMethod(), order(series))
+            @test all(iszero, values(series - series_avf))
+        end
+
         @testset "Example in Section 4.2 of Miyatake and Butcher (2016)" begin
             # - Yuto Miyatake and John C. Butcher.
             #   "A characterization of energy-preserving methods and the construction of

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1552,6 +1552,118 @@ using Aqua: Aqua
         end
     end # @testset "Rosenbrock methods interface"
 
+    @testset "Continuous stage Runge-Kutta methods interface" begin
+        @testset "Average vector field method" begin
+            M = fill(1//1, 1, 1)
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 8)
+            series = bseries(csrk, 8)
+            series_avf = @inferred bseries(AverageVectorFieldMethod(), order(series))
+            @test all(iszero, values(series - series_avf))
+        end
+
+        @testset "Example in Section 4.2 of Miyatake and Butcher (2016)" begin
+            # - Yuto Miyatake and John C. Butcher.
+            #   "A characterization of energy-preserving methods and the construction of
+            #   parallel integrators for Hamiltonian systems."
+            #   SIAM Journal on Numerical Analysis 54, no. 3 (2016):
+            #   [DOI: 10.1137/15M1020861](https://doi.org/10.1137/15M1020861)
+            M = [-6//5 72//5 -36//1 24//1
+                 72//5  -144//5 -48//1 72//1
+                 -36//1 -48//1 720//1 -720//1
+                 24//1 72//1 -720//1 720//1]
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 6)
+            series = bseries(csrk, 6)
+
+            @test @inferred(order_of_accuracy(series)) == 4
+            @test is_energy_preserving(series)
+
+            # Now with floating point coefficients
+            M = Float64.(M)
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 6)
+            series = bseries(csrk, 6)
+
+            @test @inferred(order_of_accuracy(series)) == 4
+            @test_broken is_energy_preserving(series)
+        end
+
+        @testset "SymEngine.jl" begin
+            # Examples in Section 5.3.1
+            α = SymEngine.symbols("α")
+            α1 = 1 / (36 * α - 7)
+            M = [α1+4 -6*α1-6 6*α1
+                 -6*α1-6 36*α1+12 -36*α1
+                 6*α1 -36*α1 36*α1]
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 5)
+            series = bseries(csrk, 5)
+
+            # The simple test does not work at the moment due to missing
+            # simplifications in SymEngine.jl
+            @test_broken @inferred(order_of_accuracy(series)) == 4
+            exact = @inferred ExactSolution(series)
+            for o in 1:4
+                for t in RootedTreeIterator(o)
+                    expr = SymEngine.expand(series[t] - exact[t])
+                    @test iszero(SymEngine.expand(1 * expr))
+                end
+            end
+
+            # TODO: This is currently not implemented
+            @test_broken is_energy_preserving(series)
+        end
+
+        @testset "SymPy.jl" begin
+            # Examples in Section 5.3.1
+            α = SymPy.symbols("α", real = true)
+            α1 = 1 / (36 * α - 7)
+            M = [α1+4 -6*α1-6 6*α1
+                 -6*α1-6 36*α1+12 -36*α1
+                 6*α1 -36*α1 36*α1]
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 5)
+            series = bseries(csrk, 5)
+
+            @test @inferred(order_of_accuracy(series)) == 4
+
+            # TODO: This is currently not implemented
+            @test_broken is_energy_preserving(series)
+        end
+
+        @testset "Symbolics.jl" begin
+            # Examples in Section 5.3.1
+            Symbolics.@variables α
+            α1 = 1 / (36 * α - 7)
+            M = [α1+4 -6*α1-6 6*α1
+                 -6*α1-6 36*α1+12 -36*α1
+                 6*α1 -36*α1 36*α1]
+            csrk = @inferred ContinuousStageRungeKuttaMethod(M)
+
+            # TODO: This is no type stable at the moment
+            # series = @inferred bseries(csrk, 2)
+            series = bseries(csrk, 2)
+
+            # TODO: There are errors from Symbolics.jl if we go to higher
+            #       orders.
+            # @test @inferred(order_of_accuracy(series)) == 4
+
+            # # TODO: This is currently not implemented
+            @test_broken is_energy_preserving(series)
+        end
+    end
+
     @testset "multirate infinitesimal split methods interface" begin
         # NOTE: This is still considered experimental and might change at any time!
 


### PR DESCRIPTION
I drafted a first version of continuous stage Runge-Kutta methods using Polynomials.jl to evaluate the integrals. It appears to be several orders of magnitude faster than #144 but can certainly be improved even more. For example, `derivative_weight` and `elementary_weight` are not type stable due to problems with Polynomials.jl and recursion.

A good approach may be to get this as a first version into `main` and improve the implementation later on.

CC @ketch @Sondar74 